### PR TITLE
Sanitize national_id param in user creation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pundit
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   rescue_from ActiveRecord::RecordNotFound, :with => :record_not_found
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
@@ -13,4 +15,11 @@ class ApplicationController < ActionController::API
   def record_not_found(error)
     render json: { error: error.message }, status: :not_found
   end
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:national_id])
+  end
+
 end


### PR DESCRIPTION
national_id is required for users, so it must be part of user sign_up
now we can create users doing a POST to /auth with email, password, national_id